### PR TITLE
* Add more specific S3 support

### DIFF
--- a/lib/iamspec.rb
+++ b/lib/iamspec.rb
@@ -2,9 +2,11 @@ require 'aws-sdk'
 require 'iamspec/version'
 require 'iamspec/helpers/account'
 require 'iamspec/matcher/be_allowed_to'
+require 'iamspec/matcher/not_be_allowed_to'
 require 'iamspec/type/generic_policy_source'
 require 'iamspec/type/arn_policy_source'
 require 'iamspec/action/generic_action'
+require 'iamspec/action/s3_action'
 require 'iamspec/action/assume_role'
 
 extend Iamspec::Type

--- a/lib/iamspec/action/generic_action.rb
+++ b/lib/iamspec/action/generic_action.rb
@@ -61,7 +61,7 @@ module Iamspec::Action
       end
       iam = Aws::IAM::Client.new(opts)
       @userid = iam.get_role(role_name: role_arn).role.role_id
-      @context_entries[:userid] = Aws::IAM::Types::ContextEntry.new({context_key_name: "aws:userid", context_key_values: ["#{@userid}:test"], context_key_type: "string"})
+      @context_entries[:userid] = Aws::IAM::Types::ContextEntry.new({context_key_name: "aws:userid", context_key_values: ["#{@userid}:#{role_arn}"], context_key_type: "string"})
       self
     end
 

--- a/lib/iamspec/action/generic_action.rb
+++ b/lib/iamspec/action/generic_action.rb
@@ -1,18 +1,33 @@
 module Iamspec::Action
   def perform_action(action_name, resource_arns = [])
-    GenericAction.new([action_name], resource_arns)
+    GenericAction.new([action_name], nil, resource_arns)
   end
+
+  def perform_action_with_caller_arn(action_name, caller_arn, resource_arns = [])
+    GenericAction.new([action_name], caller_arn, resource_arns)
+  end
+
   def perform_actions(action_names, resource_arns = [])
-    GenericAction.new(action_names, resource_arns)
+    GenericAction.new(action_names, nil, resource_arns)
   end
 
   class GenericAction
     attr_reader :action_names
+    attr_reader :caller_arn
     attr_reader :resource_arns
+    attr_reader :creds
+    attr_reader :policy_string
+    attr_reader :policy
+    attr_reader :userid
+    attr_reader :sourcevpce
+    attr_reader :sourceip
+    attr_reader :context_entries
 
-    def initialize(action_names, resource_arns)
+    def initialize(action_names, caller_arn, resource_arns)
+      @caller_arn = caller_arn
       @action_names = action_names
       @resource_arns = resource_arns
+      @context_entries = {}
     end
 
     def to_s
@@ -23,8 +38,50 @@ module Iamspec::Action
       end
     end
 
+    def with_credentials(creds)
+      @creds = creds
+      self
+    end
+
     def with_resource(resource_arn)
       @resource_arns = [resource_arn]
+      self
+    end
+
+    def with_policy(policy)
+      @policy = policy
+      self
+    end
+
+    def with_userid(userid)
+      @userid = userid
+      @context_entries[:userid] = Aws::IAM::Types::ContextEntry.new({context_key_name: "aws:userid", context_key_values: [userid], context_key_type: "string"})
+      self
+    end
+
+    def with_sourcevpce(sourcevpce)
+      @sourcevpce = sourcevpce
+      @context_entries[:sourcevpce] = Aws::IAM::Types::ContextEntry.new({context_key_name: "aws:sourceVpce", context_key_values: [sourcevpce], context_key_type: "string"})
+      self
+    end
+
+    def with_sourceip(sourceip)
+      @sourceip = sourceip
+      @context_entries[:sourceip] = Aws::IAM::Types::ContextEntry.new({context_key_name: "aws:SourceIp", context_key_values: [sourceip], context_key_type: "string"})
+      self
+    end
+
+
+    def with_resource_policy(role_arn = nil, resource_arns = @resource_arns)
+      @resource_arns.each do |arn|
+        if arn.start_with?('arn:aws:s3:::')
+          bucket = arn.scan(/arn:aws:s3:::([^\/]+)/).last.first
+          sts = Aws::STS::Client.new()
+          res = sts.assume_role(role_arn: role_arn, role_session_name: 'temp')
+          s3 = Aws::S3::Client.new(:credentials => res)
+          @policy_string = s3.get_bucket_policy(:bucket => bucket).policy.read
+        end
+      end
       self
     end
   end

--- a/lib/iamspec/action/generic_action.rb
+++ b/lib/iamspec/action/generic_action.rb
@@ -23,7 +23,7 @@ module Iamspec::Action
     attr_reader :sourceip
     attr_reader :context_entries
 
-    def initialize(action_names, caller_arn, resource_arns)
+    def initialize(action_names, caller_arn = nil, resource_arns)
       @caller_arn = caller_arn
       @action_names = action_names
       @resource_arns = resource_arns

--- a/lib/iamspec/action/generic_action.rb
+++ b/lib/iamspec/action/generic_action.rb
@@ -53,6 +53,18 @@ module Iamspec::Action
       self
     end
 
+    def with_userid_from_role_arn(role_arn, assume_role_arn = nil)
+      opts = {}
+      if assume_role_arn
+        sts = Aws::STS::Client.new()
+        opts[:credentials] = sts.assume_role(role_arn: assume_role_arn, role_session_name: 'temp')
+      end
+      iam = Aws::IAM::Client.new(opts)
+      @userid = iam.get_role(role_name: role_arn).role.role_id
+      @context_entries[:userid] = Aws::IAM::Types::ContextEntry.new({context_key_name: "aws:userid", context_key_values: ["#{@userid}:test"], context_key_type: "string"})
+      self
+    end
+
     def with_userid(userid)
       @userid = userid
       @context_entries[:userid] = Aws::IAM::Types::ContextEntry.new({context_key_name: "aws:userid", context_key_values: [userid], context_key_type: "string"})

--- a/lib/iamspec/action/s3_action.rb
+++ b/lib/iamspec/action/s3_action.rb
@@ -1,0 +1,35 @@
+module Iamspec::Action
+  def perform_s3_action(action_name, resource_arns = [])
+    S3Action.new([action_name], nil, resource_arns)
+  end
+
+  def perform_s3_action_with_caller_arn(action_name, caller_arn, resource_arns = [])
+    S3Action.new([action_name], caller_arn, resource_arns)
+  end
+
+  def perform_s3_actions(action_names, resource_arns = [])
+    S3Action.new(action_names, nil, resource_arns)
+  end
+
+  class S3Action < GenericAction
+    attr_reader :sse_encryption_aws_kms_key_id
+    attr_reader :sse
+
+    def initialize(action_names, caller_arn, resource_arns)
+      super(action_names, caller_arn, resource_arns)
+    end
+
+    def with_sse(sse)
+      @sse = sse
+      @context_entries[:sse] = Aws::IAM::Types::ContextEntry.new({context_key_name: "s3:x-amz-server-side-encryption", context_key_values: [sse], context_key_type: "string"})
+      self
+    end
+
+    def with_sse_encryption_aws_kms_key_id(sse_encryption_aws_kms_key_id)
+      @sse_encryption_aws_kms_key_id = sse_encryption_aws_kms_key_id
+      @context_entries[:sse_encryption_aws_kms_key_id] = Aws::IAM::Types::ContextEntry.new({context_key_name: "s3:x-amz-server-side-encryption-aws-kms-key-id", context_key_values: [sse_encryption_aws_kms_key_id], context_key_type: "string"})
+      self
+    end
+
+  end
+end

--- a/lib/iamspec/matcher/be_allowed_to.rb
+++ b/lib/iamspec/matcher/be_allowed_to.rb
@@ -15,7 +15,7 @@ class BeAllowedTo < GenericAllowedTo
   end
 
   def description
-    "be allowed to #{@action.to_s} #{@action.userid ? 'with userid ' + @action.userid : ''}"
+    "be allowed to #{@action.to_s}#{@action.userid ? ' with userid ' + @action.userid : ''}"
   end
 
   def failure_message
@@ -26,21 +26,7 @@ class BeAllowedTo < GenericAllowedTo
     @evaluation_results.map {|result| "#{result.eval_action_name} is allowed"}.join("\n")
   end
 
-  def actual
-    @evaluation_results.map {|result| "#{result.eval_action_name} is #{result.eval_decision}"}.join("\n")
-  end
-
-  def diffable?
-    true
-  end
-
   private
-
-  def failure_strings(results)
-    failure_results(results)
-        .map { |result| "#{result.eval_decision} for #{result.eval_action_name}"}
-        .join(' and ')
-  end
 
   def failure_results(results)
     results.select {|result| result.eval_decision != 'allowed'}

--- a/lib/iamspec/matcher/generic_allowed_to.rb
+++ b/lib/iamspec/matcher/generic_allowed_to.rb
@@ -1,0 +1,22 @@
+class GenericAllowedTo
+  def matches?(subject)
+    @subject = subject
+    iam_opts ||= {region: 'us-east-1'}
+    iam_opts[:credentials] = @action.creds if @action and @action.creds
+    iam = Aws::IAM::Client.new(iam_opts)
+    opts = {
+        action_names: @action.action_names,
+        resource_arns: @action.resource_arns,
+    }
+    opts[:policy_source_arn] = subject.arn if subject.is_a? Iamspec::Type::GenericPolicySource
+    opts[:policy_input_list] = [@action.policy] if @action.policy
+    opts[:caller_arn] = @action.caller_arn if @action.caller_arn
+    opts[:context_entries] = @action.context_entries.values
+    opts[:resource_policy] = @action.policy_string if @action.policy_string
+    resp = iam.simulate_principal_policy(opts)
+
+    # puts "fooo: #{resp.evaluation_results}"
+
+    resp.evaluation_results
+  end
+end

--- a/lib/iamspec/matcher/generic_allowed_to.rb
+++ b/lib/iamspec/matcher/generic_allowed_to.rb
@@ -19,4 +19,20 @@ class GenericAllowedTo
 
     resp.evaluation_results
   end
+
+  def actual
+    @evaluation_results.map {|result| "#{result.eval_action_name} is #{result.eval_decision}"}.join("\n")
+  end
+
+  def diffable?
+    true
+  end
+
+  private
+
+  def failure_strings(results)
+    failure_results(results)
+        .map {|result| "#{result.eval_decision} for #{result.eval_action_name}"}
+        .join(' and ')
+  end
 end

--- a/lib/iamspec/matcher/not_be_allowed_to.rb
+++ b/lib/iamspec/matcher/not_be_allowed_to.rb
@@ -1,10 +1,10 @@
 require_relative 'generic_allowed_to.rb'
 
-def be_allowed_to(action)
-  BeAllowedTo.new(action)
+def not_be_allowed_to(action)
+  NotBeAllowedTo.new(action)
 end
 
-class BeAllowedTo < GenericAllowedTo
+class NotBeAllowedTo < GenericAllowedTo
   def initialize(action)
     @action = action
   end
@@ -15,11 +15,11 @@ class BeAllowedTo < GenericAllowedTo
   end
 
   def description
-    "be allowed to #{@action.to_s} #{@action.userid ? 'with userid ' + @action.userid : ''}"
+    "not be allowed to #{@action.to_s} #{@action.userid ? 'with userid ' + @action.userid : ''}"
   end
 
   def failure_message
-    "wasn't allowed because of #{failure_strings(@evaluation_results)}"
+    "#{@action.to_s} was allowed because of #{failure_strings(@evaluation_results)}"
   end
 
   def expected
@@ -38,12 +38,12 @@ class BeAllowedTo < GenericAllowedTo
 
   def failure_strings(results)
     failure_results(results)
-        .map { |result| "#{result.eval_decision} for #{result.eval_action_name}"}
+        .map {|result| "#{result.eval_decision} for #{result.eval_action_name}"}
         .join(' and ')
   end
 
   def failure_results(results)
-    results.select {|result| result.eval_decision != 'allowed'}
+    results.select {|result| result.eval_decision == 'allowed'}
   end
 
 end

--- a/lib/iamspec/matcher/not_be_allowed_to.rb
+++ b/lib/iamspec/matcher/not_be_allowed_to.rb
@@ -15,7 +15,7 @@ class NotBeAllowedTo < GenericAllowedTo
   end
 
   def description
-    "not be allowed to #{@action.to_s} #{@action.userid ? 'with userid ' + @action.userid : ''}"
+    "not be allowed to #{@action.to_s}#{@action.userid ? ' with userid ' + @action.userid : ''}"
   end
 
   def failure_message
@@ -23,11 +23,7 @@ class NotBeAllowedTo < GenericAllowedTo
   end
 
   def expected
-    @evaluation_results.map {|result| "#{result.eval_action_name} is allowed"}.join("\n")
-  end
-
-  def actual
-    @evaluation_results.map {|result| "#{result.eval_action_name} is #{result.eval_decision}"}.join("\n")
+    @evaluation_results.map {|result| "#{result.eval_action_name} is not allowed"}.join("\n")
   end
 
   def diffable?
@@ -35,12 +31,6 @@ class NotBeAllowedTo < GenericAllowedTo
   end
 
   private
-
-  def failure_strings(results)
-    failure_results(results)
-        .map {|result| "#{result.eval_decision} for #{result.eval_action_name}"}
-        .join(' and ')
-  end
 
   def failure_results(results)
     results.select {|result| result.eval_decision == 'allowed'}


### PR DESCRIPTION
Very cool idea!! I was looking for exactly this!

These are some of my additions. I am currently using it like this:
```

    describe("When accessing mybucket bucket") do
      before(:all) do
        sts = Aws::STS::Client.new()
        @base_creds = sts.assume_role(role_arn: 'arn:aws:iam::22222222222:role/admin', role_session_name: 'temp')
      end
 context "with uploader role" do
      describe "testing upload with the wrong KMS key" do
        describe generic_policy_source("arn:aws:iam::22222222222:user/simple") do
          it {
            should not_be_allowed_to perform_s3_action_with_caller_arn('s3:PutObject', "arn:aws:iam::22222222222:user/simple")
                                         .with_credentials(@base_creds)
                                         .with_resource("arn:aws:s3:::mybucket/test")                                         
                                         .with_userid("AAAAAAAAAAAAAAAAAA:blah")
                                         .with_sourceip("8.8.8.8")
                                         .with_sse("aws:kms")
                                         .with_sse_encryption_aws_kms_key_id("arn:aws:kms:us-east-1:111111111111:key/FFFFFFF-FFFF-FFFF-FFFF-CCCCCCCCCC")
                                         .with_resource_policy('arn:aws:iam::111111111111:role/admin')
                                         .with_policy('{
    "Version": "2012-10-17",
    "Statement": [
        {
            "Effect": "Allow",
            "Action": "s3:*",
            "Resource": "*"
        }
    ]
}')
          }
        end
      end

      describe "testing upload without SSE" do
        describe generic_policy_source("arn:aws:iam::22222222222:user/simple") do
          it {
            should not_be_allowed_to perform_s3_action_with_caller_arn('s3:PutObject', "arn:aws:iam::22222222222:user/simple")
                                         .with_credentials(@base_creds)
                                         .with_resource("arn:aws:s3:::mybucket/test")                                         
                                         .with_userid("AAAAAAAAAAAAAAAAAA:blah")
                                         .with_sourceip("8.8.8.8")
                                         .with_resource_policy('arn:aws:iam::111111111111:role/admin')
                                         .with_policy('{
    "Version": "2012-10-17",
    "Statement": [
        {
            "Effect": "Allow",
            "Action": "s3:*",
            "Resource": "*"
        }
    ]
}')
          }
        end
      end

      describe "testing upload with the right KMS key" do
        describe generic_policy_source("arn:aws:iam::22222222222:user/simple") do
          it {
            should be_allowed_to perform_s3_action_with_caller_arn('s3:PutObject', "arn:aws:iam::22222222222:user/simple")
                                         .with_credentials(@base_creds)
                                         .with_resource("arn:aws:s3:::mybucket/test")
                                         .with_userid("AAAAAAAAAAAAAAAAAA:blah")
                                         .with_sourceip("8.8.8.8")
                                         .with_sse("aws:kms")
                                         .with_sse_encryption_aws_kms_key_id("arn:aws:kms:us-east-1:111111111111:key/FFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFF")
                                         .with_resource_policy('arn:aws:iam::111111111111:role/admin')
                                         .with_policy('{
    "Version": "2012-10-17",
    "Statement": [
        {
            "Effect": "Allow",
            "Action": "s3:*",
            "Resource": "*"
        }
    ]
}')
          }
        end
      end
    end
  end
```
