### PR TITLE
failure_message_when_negated implementation added

### DIFF
--- a/lib/iamspec/matcher/be_allowed_to.rb
+++ b/lib/iamspec/matcher/be_allowed_to.rb
@@ -21,6 +21,10 @@ class BeAllowedTo < GenericAllowedTo
   def failure_message
     "wasn't allowed because of #{failure_strings(@evaluation_results)}"
   end
+  
+  def failure_message_when_negated
+    @evaluation_results.map {|result| "#{result.eval_action_name} was allowed"}.join("\n")
+  end
 
   def expected
     @evaluation_results.map {|result| "#{result.eval_action_name} is allowed"}.join("\n")


### PR DESCRIPTION
failure_message_when_negated is called when a should_not be_allowed_to control fails to pass